### PR TITLE
fix: remove .env directory if one exists

### DIFF
--- a/.ebextensions/env-file-creation.config
+++ b/.ebextensions/env-file-creation.config
@@ -28,6 +28,9 @@ files:
                 exit 1
             fi
         else
+            if [ -d ${TARGET_DIR}/.env ]; then
+                rm -rf ${TARGET_DIR}/.env
+            fi
             echo "Directory ${TARGET_DIR} already exists!"
         fi
 


### PR DESCRIPTION
For some reason `.env` is a directory. This is hopefully removing the directory so we can create a file